### PR TITLE
Allow subclassing

### DIFF
--- a/MochaJSDelegate.js
+++ b/MochaJSDelegate.js
@@ -6,10 +6,12 @@
 //  Copyright (c) 2015. All rights reserved.
 //
 
-var MochaJSDelegate = function(selectorHandlerDict){
+var MochaJSDelegate = function(selectorHandlerDict, superclass){
 	var uniqueClassName = "MochaJSDelegate_DynamicClass_" + NSUUID.UUID().UUIDString();
-
-	var delegateClassDesc = MOClassDescription.allocateDescriptionForClassWithName_superclass_(uniqueClassName, NSObject);
+	
+	//	OPTIONAL: Allow subclassing of a superclass
+	superclass = superclass ? superclass : NSObject;
+	var delegateClassDesc = MOClassDescription.allocateDescriptionForClassWithName_superclass_(uniqueClassName, superclass);
 	
 	delegateClassDesc.registerClass();
 


### PR DESCRIPTION
Adds a `superclass` optional param (if nil, we use NSObject) to let you subclass something. This allows you to do function overrides with the same setHandler method

e.g. this allowed me to override keyUp for an NSTextField

```
  var textFieldKeyLogged = new MochaJSDelegate({
      "keyUp:": (function(event) {
        var keyCode = event.keyCode();
        keyUpHandler(keyCode);
      })
  }, NSTextField);
  var NSTextFieldKeyLogged = textFieldKeyLogged.getClass();
  var textField = [[NSTextFieldKeyLogged alloc] initWithFrame:rect];
```
